### PR TITLE
chore: temporary fix npm run build

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g appium@next
+    - run: npm install -g appium
     - run: |
         cd driver
         npm install

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -48,6 +48,17 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
   public proxydriverName: string; // to store 'driver name' as proxy to.
   public device: any;
 
+  // FIXME: from BaseDriver
+  public opts: any;
+  public caps: any;
+  public clearNewCommandTimeout: any;
+  public startNewCommandTimeout: any;
+  public relaxedSecurityEnabled: any;
+  public denyInsecure: any;
+  public allowInsecure: any;
+  public desiredCapConstraints: any;
+  public log: any;
+
   // Used to keep the capabilities internally
   public internalCaps: DriverCaps<FluttertDriverConstraints>;
 
@@ -211,4 +222,3 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
 }
 
 export { FlutterDriver };
-

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -57,7 +57,6 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
   public denyInsecure: any;
   public allowInsecure: any;
   public desiredCapConstraints: any;
-  public log: any;
 
   // Used to keep the capabilities internally
   public internalCaps: DriverCaps<FluttertDriverConstraints>;


### PR DESCRIPTION
temporary fixed npm run build error.
Hm, i thought it was in the ci, but maybe not?

Let me tweak dev env later as well

```
npm ERR! code 1
npm ERR! path /Users/kazu/GitHub/appium-flutter-driver/driver
npm ERR! command failed
npm ERR! command sh -c npm run clean && npm run build
npm ERR! > appium-flutter-driver@1.22.0 clean
npm ERR! > npm run build -- --clean
npm ERR!
npm ERR!
npm ERR! > appium-flutter-driver@1.22.0 build
npm ERR! > tsc -b "--clean"
npm ERR!
npm ERR!
npm ERR! > appium-flutter-driver@1.22.0 build
npm ERR! > tsc -b
npm ERR!
npm ERR! lib/sessions/session.ts(10,10): error TS2339: Property 'log' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(22,12): error TS2339: Property 'log' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(34,58): error TS2339: Property 'relaxedSecurityEnabled' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(35,48): error TS2339: Property 'denyInsecure' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(36,49): error TS2339: Property 'allowInsecure' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(41,58): error TS2339: Property 'relaxedSecurityEnabled' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(42,48): error TS2339: Property 'denyInsecure' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(43,49): error TS2339: Property 'allowInsecure' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(47,16): error TS2339: Property 'log' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(53,29): error TS2339: Property 'opts' does not exist on type 'FlutterDriver'.
npm ERR! lib/sessions/session.ts(61,8): error TS2339: Property 'log' does not exist on type 'FlutterDriver'.
npm ERR! lib/driver.ts(96,10): error TS2339: Property 'desiredCapConstraints' does not exist on type 'FlutterDriver'.
npm ERR! lib/driver.ts(178,14): error TS2339: Property 'clearNewCommandTimeout' does not exist on type 'FlutterDriver'.
npm ERR! lib/driver.ts(180,14): error TS2339: Property 'startNewCommandTimeout' does not exist on type 'FlutterDriver'.
```