### PR TITLE
Fixed typo in executeElementCommand 

### DIFF
--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -195,7 +195,7 @@ export const executeElementCommand = async function(
   log.debug(`<<< ${JSON.stringify(data)} | previous command ${command}`);
   if (data.isError) {
     throw new Error(
-      `Cannot execute command ${command}, server reponse ${JSON.stringify(data, null, 2)}`,
+      `Cannot execute command ${command}, server response ${JSON.stringify(data, null, 2)}`,
     );
   }
   return data.response;


### PR DESCRIPTION
Changed 'server reponse' to 'server response' in the executeElementCommand error. This is a duplicate of an earlier PR I made with some errors in it.