### PR TITLE
fix: leftover portforward

### DIFF
--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -1,11 +1,6 @@
 // @ts-ignore: no 'errors' export module
 import _ from 'lodash';
 import { BaseDriver } from 'appium/driver';
-import type {
-  DefaultCreateSessionResult, DriverCaps, DriverData, W3CDriverCaps,
-  RouteMatcher
-} from '@appium/types';
-import type { IsolateSocket } from './sessions/isolate_socket';
 import { log as logger } from './logger';
 import {
   executeElementCommand, executeGetVMCommand, executeGetIsolateCommand
@@ -24,6 +19,12 @@ import { getClipboard, setClipboard } from './commands/clipboard';
 import { desiredCapConstraints } from './desired-caps';
 import XCUITestDriver from 'appium-xcuitest-driver';
 import AndroidUiautomator2Driver from 'appium-uiautomator2-driver';
+import type {
+  DefaultCreateSessionResult, DriverCaps, DriverData, W3CDriverCaps,
+  RouteMatcher
+} from '@appium/types';
+import type { IsolateSocket } from './sessions/isolate_socket';
+import type { Server } from 'rpc-websockets';
 
 
 type FluttertDriverConstraints = typeof desiredCapConstraints;
@@ -49,7 +50,7 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
   public device: any;
 
   public portForwardLocalPort: string | null;
-  public localServer: any;
+  public localServer: Server | null;
 
   // Used to keep the capabilities internally
   public internalCaps: DriverCaps<FluttertDriverConstraints>;

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -97,7 +97,10 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
     this.device = null;
     this.desiredCapConstraints = desiredCapConstraints;
 
+    // Used to keep the port for port forward to clear the pair.
     this.portForwardLocalPort = null;
+
+    // Used for iOS to end the local server to proxy the request.
     this.localServer = null;
   }
 
@@ -114,6 +117,7 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
     switch (_.toLower(this.internalCaps.platformName)) {
       case PLATFORM.IOS:
         this.localServer?.close();
+        this.localServer = null;
         break;
       case PLATFORM.ANDROID:
         if (this.portForwardLocalPort) {

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -10,7 +10,8 @@ import { log as logger } from './logger';
 import {
   executeElementCommand, executeGetVMCommand, executeGetIsolateCommand
 } from './sessions/observatory';
-import { createSession, reConnectFlutterDriver, PLATFORM } from './sessions/session';
+import { PLATFORM } from './platform';
+import { createSession, reConnectFlutterDriver } from './sessions/session';
 import {
   driverShouldDoProxyCmd, FLUTTER_CONTEXT_NAME,
   getContexts, getCurrentContext, NATIVE_CONTEXT_NAME, setContext

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -24,7 +24,7 @@ import type {
   RouteMatcher
 } from '@appium/types';
 import type { IsolateSocket } from './sessions/isolate_socket';
-import type { Server } from 'rpc-websockets';
+import type { Server } from 'node:net';
 
 
 type FluttertDriverConstraints = typeof desiredCapConstraints;

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -126,7 +126,6 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
       }
       this.proxydriver = null;
     }
-    // TODO: should remove the port forward for Android and iOS.
 
     await super.deleteSession();
   }

--- a/driver/lib/platform.ts
+++ b/driver/lib/platform.ts
@@ -1,0 +1,5 @@
+export const PLATFORM = {
+  IOS: 'ios',
+  ANDROID: 'android',
+} as const;
+

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -52,10 +52,10 @@ export const getObservatoryWsUri = async (
   } else {
     urlObject = fetchObservatoryUrl(proxydriver.adb.logcat!.logs as [{message: string}]);
   }
-  flutterDriver.portForwardRemotePort = urlObject.port;
-  flutterDriver.portForwardLocalPort = caps.forwardingPort ?? flutterDriver.portForwardRemotePort;
+  const remotePort = urlObject.port;
+  flutterDriver.portForwardLocalPort = caps.forwardingPort ?? remotePort;
   urlObject.port = flutterDriver.portForwardLocalPort!;
-  await proxydriver.adb.forwardPort(flutterDriver.portForwardLocalPort!, flutterDriver.portForwardRemotePort);
+  await proxydriver.adb.forwardPort(flutterDriver.portForwardLocalPort!, remotePort);
   if (!caps.observatoryWsUri && proxydriver.adb.adbHost) {
     urlObject.host = proxydriver.adb.adbHost;
   }

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -3,6 +3,7 @@ import { log } from '../logger';
 import { connectSocket, fetchObservatoryUrl } from './observatory';
 import type { InitialOpts } from '@appium/types';
 import type { IsolateSocket } from './isolate_socket';
+import { FlutterDriver } from '../driver';
 
 const setupNewAndroidDriver = async (...args: any[]): Promise<AndroidUiautomator2Driver> => {
   const androiddriver = new AndroidUiautomator2Driver({} as InitialOpts);
@@ -12,7 +13,9 @@ const setupNewAndroidDriver = async (...args: any[]): Promise<AndroidUiautomator
 };
 
 export const startAndroidSession = async (
-  caps: Record<string, any>, ...args: any[]
+  flutterDriver: FlutterDriver,
+  caps: Record<string, any>,
+  ...args: any[]
 ): Promise<[AndroidUiautomator2Driver, IsolateSocket|null]> => {
   log.info(`Starting an Android proxy session`);
   const androiddriver = await setupNewAndroidDriver(...args);
@@ -24,16 +27,19 @@ export const startAndroidSession = async (
 
   return [
     androiddriver,
-    await connectSocket(getObservatoryWsUri, androiddriver, caps),
+    await connectSocket(getObservatoryWsUri, flutterDriver, androiddriver, caps),
   ];
 };
 
 export const connectAndroidSession = async (
-  androiddriver: AndroidUiautomator2Driver, caps: Record<string, any>
+  flutterDriver: FlutterDriver, androiddriver: AndroidUiautomator2Driver, caps: Record<string, any>
 ): Promise<IsolateSocket> =>
-  await connectSocket(getObservatoryWsUri, androiddriver, caps);
+  await connectSocket(getObservatoryWsUri, flutterDriver, androiddriver, caps);
 
-export const getObservatoryWsUri = async (proxydriver: AndroidUiautomator2Driver, caps): Promise<string> => {
+export const getObservatoryWsUri = async (
+  flutterDriver: FlutterDriver,
+  proxydriver: AndroidUiautomator2Driver,
+  caps): Promise<string> => {
   let urlObject: URL;
   if (caps.observatoryWsUri) {
     urlObject = new URL(caps.observatoryWsUri);
@@ -46,10 +52,10 @@ export const getObservatoryWsUri = async (proxydriver: AndroidUiautomator2Driver
   } else {
     urlObject = fetchObservatoryUrl(proxydriver.adb.logcat!.logs as [{message: string}]);
   }
-  const remotePort = urlObject.port;
-  const localPort = caps.forwardingPort ?? remotePort;
-  urlObject.port = localPort;
-  await proxydriver.adb.forwardPort(localPort, remotePort);
+  flutterDriver.portForwardRemotePort = urlObject.port;
+  flutterDriver.portForwardLocalPort = caps.forwardingPort ?? flutterDriver.portForwardRemotePort;
+  urlObject.port = flutterDriver.portForwardLocalPort!;
+  await proxydriver.adb.forwardPort(flutterDriver.portForwardLocalPort!, flutterDriver.portForwardRemotePort);
   if (!caps.observatoryWsUri && proxydriver.adb.adbHost) {
     urlObject.host = proxydriver.adb.adbHost;
   }

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -104,10 +104,10 @@ export const getObservatoryWsUri = async (
     remoteSocket.pipe(localSocket);
   });
   const listeningPromise = new B((resolve, reject) => {
-    flutterDriver.localServer.once(`listening`, resolve);
-    flutterDriver.localServer.once(`error`, reject);
+    flutterDriver.localServer?.once(`listening`, resolve);
+    flutterDriver.localServer?.once(`error`, reject);
   });
-  flutterDriver.localServer.listen(localPort);
+  flutterDriver.localServer?.listen(localPort);
   try {
     await listeningPromise;
   } catch (e) {
@@ -117,7 +117,7 @@ export const getObservatoryWsUri = async (
   log.info(`Forwarding the remote port ${remotePort} to the local port ${localPort}`);
 
   process.on(`beforeExit`, () => {
-    flutterDriver.localServer.close();
+    flutterDriver.localServer?.close();
   });
   return urlObject.toJSON();
 };

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -154,7 +154,14 @@ export const connectSocket = async (
       }
     }
 
-    // TODO: should remove the port forward for Android and iOS before the retrial.
+
+    // TODO: define the same method name.
+    // ios
+    flutterDriver.localServer?.close();
+    // Android
+    if (flutterDriver.portForwardLocalPort) {
+      await driver.adb.removePortForward(flutterDriver.portForwardLocalPort);
+    }
 
     retryCount++;
   }

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -7,6 +7,7 @@ import { decode } from './base64url';
 import B from 'bluebird';
 import type XCUITestDriver from 'appium-xcuitest-driver';
 import type AndroidUiautomator2Driver from 'appium-uiautomator2-driver';
+import { PLATFORM } from '../platform';
 
 const truncateLength = 500;
 // https://github.com/flutter/flutter/blob/f90b019c68edf4541a4c8273865a2b40c2c01eb3/dev/devicelab/lib/framework/runner.dart#L183
@@ -154,13 +155,16 @@ export const connectSocket = async (
       }
     }
 
-
-    // TODO: define the same method name.
-    // ios
-    flutterDriver.localServer?.close();
-    // Android
-    if (flutterDriver.portForwardLocalPort) {
-      await driver.adb.removePortForward(flutterDriver.portForwardLocalPort);
+    // re-create the port forward
+    switch (_.toLower(caps.platformName)) {
+      case PLATFORM.IOS:
+        flutterDriver.localServer?.close();
+        break;
+      case PLATFORM.ANDROID:
+        if (flutterDriver.portForwardLocalPort) {
+          await driver.adb.removePortForward(flutterDriver.portForwardLocalPort);
+        }
+        break;
     }
 
     retryCount++;

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -54,7 +54,7 @@ export const connectSocket = async (
       urlFetchError = undefined;
     } catch (e) {
       urlFetchError = e;
-      log.debug(e.message);
+      log.debug(`Got an error while finding an observatory url. Original error: ${e.message}`);
     }
 
     if (!urlFetchError) {

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -152,6 +152,9 @@ export const connectSocket = async (
         return connectedSocket;
       }
     }
+
+    // TODO: should remove the port forward for Android and iOS before the retrial.
+
     retryCount++;
   }
   throw new Error(

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -23,7 +23,8 @@ type AnyDriver = XCUITestDriver | AndroidUiautomator2Driver;
 
 // SOCKETS
 export const connectSocket = async (
-  getObservatoryWsUri: (driver: AnyDriver, caps: any) => Promise<string>,
+  getObservatoryWsUri: (flutterDriver: FlutterDriver, driver: AnyDriver, caps: any) => Promise<string>,
+  flutterDriver: FlutterDriver,
   driver: AnyDriver,
   caps: Record<string, any>
 ): Promise<IsolateSocket> => {
@@ -50,7 +51,7 @@ export const connectSocket = async (
 
     // Every attempt gets the latest observatory url
     try {
-      dartObservatoryURL = await getObservatoryWsUri(driver, caps);
+      dartObservatoryURL = await getObservatoryWsUri(flutterDriver, driver, caps);
       urlFetchError = undefined;
     } catch (e) {
       urlFetchError = e;

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -72,4 +72,6 @@ export const deleteSession = async function(this: FlutterDriver) {
     }
     this.proxydriver = null;
   }
+
+  // TODO: should remove the port forward for Android and iOS.
 };

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -20,10 +20,10 @@ export const reConnectFlutterDriver = async function(this: FlutterDriver, caps: 
 
   switch (_.toLower(caps.platformName)) {
     case PLATFORM.IOS:
-      this.socket = await connectIOSSession(this.proxydriver, caps);
+      this.socket = await connectIOSSession(this, this.proxydriver, caps);
       break;
     case PLATFORM.ANDROID:
-      this.socket = await connectAndroidSession(this.proxydriver, caps);
+      this.socket = await connectAndroidSession(this, this.proxydriver, caps);
       break;
     default:
       this.log.errorAndThrow(
@@ -38,13 +38,13 @@ export const createSession: any = async function(this: FlutterDriver, sessionId:
     // setup proxies - if platformName is not empty, make it less case sensitive
     switch (_.toLower(caps.platformName)) {
       case PLATFORM.IOS:
-        [this.proxydriver, this.socket] = await startIOSSession(caps, ...args);
+        [this.proxydriver, this.socket] = await startIOSSession(this, caps, ...args);
         this.proxydriver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
         this.proxydriver.denyInsecure = this.denyInsecure;
         this.proxydriver.allowInsecure = this.allowInsecure;
         break;
       case PLATFORM.ANDROID:
-        [this.proxydriver, this.socket] = await startAndroidSession(caps, ...args);
+        [this.proxydriver, this.socket] = await startAndroidSession(this, caps, ...args);
         this.proxydriver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
         this.proxydriver.denyInsecure = this.denyInsecure;
         this.proxydriver.allowInsecure = this.allowInsecure;
@@ -61,17 +61,4 @@ export const createSession: any = async function(this: FlutterDriver, sessionId:
     await this.deleteSession();
     throw e;
   }
-};
-
-export const deleteSession = async function(this: FlutterDriver) {
-  if (this.proxydriver) {
-    try {
-      await this.proxydriver.deleteSession();
-    } catch (e) {
-      this.log.warn(e.message);
-    }
-    this.proxydriver = null;
-  }
-
-  // TODO: should remove the port forward for Android and iOS.
 };

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -42,6 +42,7 @@ export const createSession: any = async function(this: FlutterDriver, sessionId:
         this.proxydriver.relaxedSecurityEnabled = this.relaxedSecurityEnabled;
         this.proxydriver.denyInsecure = this.denyInsecure;
         this.proxydriver.allowInsecure = this.allowInsecure;
+
         break;
       case PLATFORM.ANDROID:
         [this.proxydriver, this.socket] = await startAndroidSession(this, caps, ...args);

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -6,11 +6,8 @@ import {
 import {
   startIOSSession, connectIOSSession
 } from './ios';
+import { PLATFORM } from '../platform';
 
-const PLATFORM = {
-  IOS: 'ios',
-  ANDROID: 'android',
-} as const;
 
 export const reConnectFlutterDriver = async function(this: FlutterDriver, caps: Record<string, any>) {
   // setup proxies - if platformName is not empty, make it less case sensitive


### PR DESCRIPTION
I found leftover ports in https://github.com/appium/appium-flutter-driver/issues/617 , we should fix

- Remove the previous port in the retrial
- Remove the current port forward in the deleteSession

For example, current method to do the port forward leftover the used ports, which is bad.

```
% adb  forward --list
D0AA002182JC0202126 tcp:8200 tcp:6790
D0AA002182JC0202126 tcp:41323 tcp:41323

% adb  forward --list
D0AA002182JC0202126 tcp:8200 tcp:6790
D0AA002182JC0202126 tcp:41323 tcp:41323
```

this will be:...

```
% adb  forward --list
D0AA002182JC0202126 tcp:8200 tcp:6790
D0AA002182JC0202126 tcp:39947 tcp:39947

% adb  forward --list
```