### PR TITLE
feat: add existing checks for android and xcuitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This snippet, taken from [example directory](example), is a script written as an
 
 Each client needs [each finder](finder) module to handle [Finders](#Finders). Appium Flutter Driver communicates with the Dart VM directory in the `FLUTTER` context.
 
+### Doctor
+Since driver version 2.4.0 you can automate the validation for the most of the above requirements as well as various optional ones needed by driver extensions by running the `appium driver doctor flutter` server command.
+The check runs for Android for UIAutomator2 driver and iOS for XCUITest driver.
+
 ### Note
 - Flutter context does not support page source
     - Please use `getRenderTree` command instead

--- a/driver/package.json
+++ b/driver/package.json
@@ -25,7 +25,15 @@
       "iOS",
       "Android"
     ],
-    "mainClass": "FlutterDriver"
+    "mainClass": "FlutterDriver",
+    "doctor": {
+      "checks": [
+        "./node_modules/appium-uiautomator2-driver/build/lib/doctor/required-checks.js",
+        "./node_modules/appium-uiautomator2-driver/build/lib/doctor/optional-checks.js",
+        "./node_modules/appium-xcuitest-driver/build/lib/doctor/required-checks.js",
+        "./node_modules/appium-xcuitest-driver/build/lib/doctor/optional-checks.js"
+      ]
+    }
   },
   "bin": {},
   "directories": {
@@ -48,7 +56,7 @@
     "clean-dependency": "rm -rf node_modules && rm -f package-lock.json"
   },
   "peerDependencies": {
-    "appium": "^2.0.0"
+    "appium": "^2.4.1"
   },
   "devDependencies": {
     "@appium/eslint-config-appium": "^8.0.4",
@@ -69,10 +77,10 @@
   },
   "dependencies": {
     "appium-adb": "^11.0.1",
-    "appium-android-driver": "^7.0.2",
+    "appium-android-driver": "^7.5.1",
     "appium-ios-device": "^2.4.1",
-    "appium-uiautomator2-driver": "^2.29.4",
-    "appium-xcuitest-driver": "^5.8.1",
+    "appium-uiautomator2-driver": "^2.39.0",
+    "appium-xcuitest-driver": "^5.13.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.1.1",
     "lodash": "^4.0.0",


### PR DESCRIPTION
https://github.com/appium/appium-flutter-driver/issues/646


~~This needs to have the flutter driver own's one.~~ <- flutter driver does not have any of this driver-specific host machine env.