### PR TITLE
fix type error

### DIFF
--- a/driver/lib/sessions/base64url.ts
+++ b/driver/lib/sessions/base64url.ts
@@ -1,14 +1,14 @@
 import _ from 'lodash';
 import { util } from '@appium/support';
 
-export const decode = (input: string | {ELEMENT: string}): string => {
-  let base64String = ``;
+export const decode = (input: string | {ELEMENT: string} | {[util.W3C_WEB_ELEMENT_IDENTIFIER]: string}): string => {
+  let base64String: string = ``;
   if (_.isString(input)) {
     base64String = input;
   } else if (_.has(input, util.W3C_WEB_ELEMENT_IDENTIFIER)) {
-    base64String = input[util.W3C_WEB_ELEMENT_IDENTIFIER];
+    base64String = input[util.W3C_WEB_ELEMENT_IDENTIFIER] as string;
   } else if (_.has(input, 'ELEMENT')) {
-    base64String = input.ELEMENT;
+    base64String = input.ELEMENT as string;
   } else {
     throw new Error(
       `Input is is expceted to be a base64-encoded string or a valid element object. ` +


### PR DESCRIPTION
```
lib/sessions/base64url.ts:9:5 - error TS2322: Type 'unknown' is not assignable to type 'string'.

9     base64String = input[util.W3C_WEB_ELEMENT_IDENTIFIER];
      ~~~~~~~~~~~~
```