### PR TITLE
feat: getWidgetDiagnostics support

### DIFF
--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -52,6 +52,8 @@ export const execute = async function(
       return await getOffset(this, args[0], { offsetType: `topRight` });
     case `getRenderObjectDiagnostics`:
       return await getRenderObjectDiagnostics(this, args[0], args[1]);
+    case `getWidgetDiagnostics`:
+      return await getWidgetDiagnostics(this, args[0], args[1]);      
     case `getSemanticsId`:
       return await getSemanticsId(this, args[0]);
     case `waitForAbsent`:
@@ -164,6 +166,27 @@ const getRenderObjectDiagnostics = async (
     elementBase64,
     {
       diagnosticsType: `renderObject`,
+      includeProperties,
+      subtreeDepth,
+    },
+  );
+};
+
+const getWidgetDiagnostics = async (
+  self: FlutterDriver,
+  elementBase64: string,
+  opts: {
+    subtreeDepth: number;
+    includeProperties: boolean;
+  },
+) => {
+  const { subtreeDepth = 0, includeProperties = true } = opts;
+
+  return await self.executeElementCommand(
+    `get_diagnostics_tree`,
+    elementBase64,
+    {
+      diagnosticsType: `widget`,
       includeProperties,
       subtreeDepth,
     },

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -53,7 +53,7 @@ export const execute = async function(
     case `getRenderObjectDiagnostics`:
       return await getRenderObjectDiagnostics(this, args[0], args[1]);
     case `getWidgetDiagnostics`:
-      return await getWidgetDiagnostics(this, args[0], args[1]);      
+      return await getWidgetDiagnostics(this, args[0], args[1]);
     case `getSemanticsId`:
       return await getSemanticsId(this, args[0]);
     case `waitForAbsent`:


### PR DESCRIPTION
This PR propose the support of the getWidgetDiagnostics [Flutter driver method](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/getWidgetDiagnostics.html) similarly to the getRenderObjectDiagnostics that is already supported.
This method is required to get widget diagnostic data and gives new opportunities to obtain more context from the application under test.