### PR TITLE
fix: wait module load

### DIFF
--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -114,10 +114,10 @@ export async function connectSocket(
               throw new Error(`"ext.flutter.driver" is not found in "extensionRPCs" ${JSON.stringify(isolate.extensionRPCs)}`);
             }
           }
-        )
+        );
       } catch (e) {
         this.log.error(e.message);
-        removeListenerAndResolve(null)
+        removeListenerAndResolve(null);
         return;
       }
       removeListenerAndResolve(socket);

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -4,6 +4,7 @@ import type { FlutterDriver } from '../driver';
 import { IsolateSocket } from './isolate_socket';
 import { decode } from './base64url';
 import type { LogEntry } from './log-monitor';
+import { retryInterval } from 'asyncbox';
 
 const truncateLength = 500;
 // https://github.com/flutter/flutter/blob/f90b019c68edf4541a4c8273865a2b40c2c01eb3/dev/devicelab/lib/framework/runner.dart#L183
@@ -16,6 +17,9 @@ export const OBSERVATORY_URL_PATTERN = new RegExp(
   `The Dart VM service is listening on )` +
   `((http|//)[a-zA-Z0-9:/=_\\-.\\[\\]]+)`,
 );
+
+const moduleCheckIntervalCount = 30;
+const moduleCheckIntervalMs = 500;
 
 // SOCKETS
 export async function connectSocket(
@@ -89,27 +93,31 @@ export async function connectSocket(
         socket.isolateId = mainIsolateData.id;
       }
 
-      // @todo check extension and do health check
-      const isolate = await socket.call(`getIsolate`, {
-        isolateId: `${socket.isolateId}`,
-      }) as {
-        extensionRPCs: [string] | null,
-      } | null;
-      if (!isolate) {
-        this.log.error(`Cannot get main Dart Isolate`);
-        removeListenerAndResolve(null);
-        return;
-      }
-      if (!Array.isArray(isolate.extensionRPCs)) {
-        this.log.error(`Cannot get Dart extensionRPCs from isolate ${JSON.stringify(isolate)}`);
-        removeListenerAndResolve(null);
-        return;
-      }
-      if (isolate.extensionRPCs.indexOf(`ext.flutter.driver`) < 0) {
-        this.log.error(
-          `"ext.flutter.driver" is not found in "extensionRPCs" ${JSON.stringify(isolate.extensionRPCs)}`
-        );
-        removeListenerAndResolve(null);
+      // It could take time to load the expected module.
+      try {
+        await retryInterval(
+          moduleCheckIntervalCount,
+          moduleCheckIntervalMs,
+          async () => {
+            const isolate = await socket.call(`getIsolate`, {
+              isolateId: `${socket.isolateId}`,
+            }) as {
+              extensionRPCs: [string] | null,
+            } | null;
+            if (!isolate) {
+              throw new Error(`Cannot get main Dart Isolate`);
+            }
+            if (!Array.isArray(isolate.extensionRPCs)) {
+              throw new Error(`Cannot get Dart extensionRPCs from isolate ${JSON.stringify(isolate)}`);
+            }
+            if (isolate.extensionRPCs.indexOf(`ext.flutter.driver`) < 0) {
+              throw new Error(`"ext.flutter.driver" is not found in "extensionRPCs" ${JSON.stringify(isolate.extensionRPCs)}`);
+            }
+          }
+        )
+      } catch (e) {
+        this.log.error(e.message);
+        removeListenerAndResolve(null)
         return;
       }
       removeListenerAndResolve(socket);

--- a/example/ruby/example_sample2.rb
+++ b/example/ruby/example_sample2.rb
@@ -12,7 +12,7 @@ class ExampleTests < Minitest::Test
       automationName: 'flutter',
       udid: 'emulator-5554',
       deviceName: 'Android',
-      app: "#{Dir.pwd}/../sample2/app-debug.apk",
+      app: "#{Dir.pwd}/example/sample2/app-debug.apk",
       maxRetryCount: 120,
       retryBackoffTime: 10000,
     },

--- a/example/ruby/example_sample2.rb
+++ b/example/ruby/example_sample2.rb
@@ -13,7 +13,7 @@ class ExampleTests < Minitest::Test
       udid: 'emulator-5554',
       deviceName: 'Android',
       app: "#{Dir.pwd}/example/sample2/app-debug.apk",
-      maxRetryCount: 120,
+      maxRetryCount: 60,
       retryBackoffTime: 10000,
     },
     appium_lib: {

--- a/example/ruby/example_sample2_ios.rb
+++ b/example/ruby/example_sample2_ios.rb
@@ -14,7 +14,7 @@ class ExampleTests < Minitest::Test
       deviceName: ENV["IOS_DEVICE_NAME"] || 'iPhone 16 Plus',
       app: "#{Dir.pwd}/../sample2/iOSFullScreen.zip",
       wdaLaunchTimeout: 600_000,
-      maxRetryCount: 120,
+      maxRetryCount: 60,
       retryBackoffTime: 10000,
 
     },


### PR DESCRIPTION
I observed the `ext.flutter.driver` module load could take some time, so one time check could fail as the module is not loaded yet.


Closes https://github.com/appium/appium-flutter-driver/issues/619 and https://github.com/appium/appium-flutter-driver/issues/758