### PR TITLE
feat: New Assertions methods and better usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,11 @@ This module extends the `appium-flutter-driver` with custom visibility-related c
 | `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
 | `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                                              | Widget     |
 | `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                                                  | Widget     |
-| `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                                                              | Widget     |
+ `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                             | Widget      |
+| `pageBack`          | ✅         | `await driver.execute('flutter:pageBack')`                                              | Navigation  |
+| `clear`             | ✅         | `await driver.execute('flutter:clear', { key: 'emailInput' })`                          | Input Field |
+
+
 
 ## 🔍 Input Formats
 

--- a/README.md
+++ b/README.md
@@ -312,12 +312,14 @@ Please replace them properly with your client.
 This module extends the `appium-flutter-driver` with custom visibility-related commands using `driver.execute()`.
 
 ## ✅ Supported Commands
-
 | **Command**         | **Status** | **Example Usage**                                                                                                         | **Target** |
 |---------------------|------------|--------------------------------------------------------------------------------------------------------------------------|------------|
 | `assertVisible`     | ✅         | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })` | Widget     |
 | `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                                                   | Widget     |
 | `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
+| `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                                              | Widget     |
+| `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                                                  | Widget     |
+| `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                                                              | Widget     |
 
 ## 🔍 Input Formats
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,18 @@ Please replace them properly with your client.
 | -                                                                                                                                  | :ok: | (Ruby) `driver.execute_script 'flutter:launchApp', 'bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` | Flutter Driver    |
 | dragAndDropWithCommandExtension                                                                                                    | :ok: | (Python) `driver.execute_script('flutter:dragAndDropWithCommandExtension', payload)` | Command Extension |
 
+## 📌 Additional Flutter Assertions (Custom)
+
+The following commands extend `appium-flutter-driver` to include widget visibility assertions. These are executed via the `driver.execute()` command (or your client equivalent).
+
+| **Assertion**      | **Status** | **Usage Example**                                                                                                                                                                                | **Target** |
+| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| `assertVisible`    | ✅          | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })`<br>`driver.execute('flutter:assertVisible', { label: 'Info icon' })` | Widget     |
+| `assertNotVisible` | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+| `assertTextEquals` | ✅          | `driver.execute('flutter:assertTextEquals', { key: 'greeting' }, 'Hello')`                                                                                                                       | Widget     |
+| `assertPresent`    | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+| `assertAbsent`     | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+
 **NOTE**
 >`flutter:launchApp` launches an app via instrument service. `mobile:activateApp` and `driver.activate_app` are via XCTest API. They are a bit different.
 

--- a/README.md
+++ b/README.md
@@ -307,17 +307,37 @@ Please replace them properly with your client.
 | -                                                                                                                                  | :ok: | (Ruby) `driver.execute_script 'flutter:launchApp', 'bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` | Flutter Driver    |
 | dragAndDropWithCommandExtension                                                                                                    | :ok: | (Python) `driver.execute_script('flutter:dragAndDropWithCommandExtension', payload)` | Command Extension |
 
-## 📌 Additional Flutter Assertions (Custom)
+# Flutter Visibility Assertions for Appium
 
-The following commands extend `appium-flutter-driver` to include widget visibility assertions. These are executed via the `driver.execute()` command (or your client equivalent).
+This module extends the `appium-flutter-driver` with custom visibility-related commands using `driver.execute()`.
 
-| **Assertion**      | **Status** | **Usage Example**                                                                                                                                                                                | **Target** |
-| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| `assertVisible`    | ✅          | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })`<br>`driver.execute('flutter:assertVisible', { label: 'Info icon' })` | Widget     |
-| `assertNotVisible` | ✅          | Same as above                                                                                                                                                                                    | Widget     |
-| `assertTextEquals` | ✅          | `driver.execute('flutter:assertTextEquals', { key: 'greeting' }, 'Hello')`                                                                                                                       | Widget     |
-| `assertPresent`    | ✅          | Same as above                                                                                                                                                                                    | Widget     |
-| `assertAbsent`     | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+## ✅ Supported Commands
+
+| **Command**         | **Status** | **Example Usage**                                                                                                         | **Target** |
+|---------------------|------------|--------------------------------------------------------------------------------------------------------------------------|------------|
+| `assertVisible`     | ✅         | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })` | Widget     |
+| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                                                   | Widget     |
+| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
+
+## 🔍 Input Formats
+
+Each assertion supports the following input formats:
+
+- `{ key: 'valueKey' }`
+- `{ text: 'Text on widget' }`
+- `{ label: 'Tooltip text' }`
+
+These map to Flutter finders:
+- `byValueKey`
+- `byText`
+- `byTooltip`
+
+## 📦 Integration
+
+These commands are typically invoked using a client helper method like:
+
+```ts
+await assertVisible(driver, { key: 'submit_button' });
 
 **NOTE**
 >`flutter:launchApp` launches an app via instrument service. `mobile:activateApp` and `driver.activate_app` are via XCTest API. They are a bit different.

--- a/driver/README.md
+++ b/driver/README.md
@@ -324,7 +324,9 @@ This module extends the `appium-flutter-driver` with custom visibility-related c
 | `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
 | `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                                              | Widget     |
 | `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                                                  | Widget     |
-| `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                                                              | Widget     |
+| `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                             | Widget      |
+| `pageBack`          | ✅         | `await driver.execute('flutter:pageBack')`                                              | Navigation  |
+| `clear`             | ✅         | `await driver.execute('flutter:clear', { key: 'emailInput' })`                          | Input Field |
 
 ## 🔍 Input Formats
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -311,16 +311,37 @@ Please replace them properly with your client.
 
 ## 📌 Additional Flutter Assertions (Custom)
 
-The following commands extend `appium-flutter-driver` to include widget visibility assertions. These are executed via the `driver.execute()` command (or your client equivalent).
+# Flutter Visibility Assertions for Appium
 
-| **Assertion**      | **Status** | **Usage Example**                                                                                                                                                                                | **Target** |
-| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| `assertVisible`    | ✅          | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })`<br>`driver.execute('flutter:assertVisible', { label: 'Info icon' })` | Widget     |
-| `assertNotVisible` | ✅          | Same as above                                                                                                                                                                                    | Widget     |
-| `assertTextEquals` | ✅          | `driver.execute('flutter:assertTextEquals', { key: 'greeting' }, 'Hello')`                                                                                                                       | Widget     |
-| `assertPresent`    | ✅          | Same as above                                                                                                                                                                                    | Widget     |
-| `assertAbsent`     | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+This module extends the `appium-flutter-driver` with custom visibility-related commands using `driver.execute()`.
 
+## ✅ Supported Commands
+
+| **Command**         | **Status** | **Example Usage**                                                                                                         | **Target** |
+|---------------------|------------|--------------------------------------------------------------------------------------------------------------------------|------------|
+| `assertVisible`     | ✅         | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })` | Widget     |
+| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                                                   | Widget     |
+| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
+
+## 🔍 Input Formats
+
+Each assertion supports the following input formats:
+
+- `{ key: 'valueKey' }`
+- `{ text: 'Text on widget' }`
+- `{ label: 'Tooltip text' }`
+
+These map to Flutter finders:
+- `byValueKey`
+- `byText`
+- `byTooltip`
+
+## 📦 Integration
+
+These commands are typically invoked using a client helper method like:
+
+```ts
+await assertVisible(driver, { key: 'submit_button' });
 Flutter API	Status	WebDriver example (JavaScript, WebDriverIO)	Scope
 
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -315,13 +315,15 @@ Please replace them properly with your client.
 
 This module extends the `appium-flutter-driver` with custom visibility-related commands using `driver.execute()`.
 
-## ✅ Supported Commands
+✅ Supported Commands
 
-| **Command**         | **Status** | **Example Usage**                                                                                                         | **Target** |
-|---------------------|------------|--------------------------------------------------------------------------------------------------------------------------|------------|
+| **Command**         | **Status** | **Example Usage**                                                                                  | **Target** |
+|---------------------|------------|-----------------------------------------------------------------------------------------------------|------------|
 | `assertVisible`     | ✅         | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })` | Widget     |
-| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                                                   | Widget     |
-| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
+| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                              | Widget     |
+| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                     | Widget     |
+| `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                         | Widget     |
+| `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                             | Widget     |
 
 ## 🔍 Input Formats
 
@@ -343,7 +345,7 @@ These commands are typically invoked using a client helper method like:
 ```ts
 await assertVisible(driver, { key: 'submit_button' });
 Flutter API	Status	WebDriver example (JavaScript, WebDriverIO)	Scope
-
+```  
 
 > **NOTE**
 > `flutter:launchApp` launches an app via instrument service. `mobile:activateApp` and `driver.activate_app` are via XCTest API. They are a bit different.

--- a/driver/README.md
+++ b/driver/README.md
@@ -317,13 +317,14 @@ This module extends the `appium-flutter-driver` with custom visibility-related c
 
 ✅ Supported Commands
 
-| **Command**         | **Status** | **Example Usage**                                                                                  | **Target** |
-|---------------------|------------|-----------------------------------------------------------------------------------------------------|------------|
+| **Command**         | **Status** | **Example Usage**                                                                                                         | **Target** |
+|---------------------|------------|--------------------------------------------------------------------------------------------------------------------------|------------|
 | `assertVisible`     | ✅         | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })` | Widget     |
-| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                              | Widget     |
-| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                     | Widget     |
-| `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                         | Widget     |
-| `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                             | Widget     |
+| `assertNotVisible`  | ✅         | `driver.execute('flutter:assertNotVisible', { key: 'hiddenWidget' })`                                                   | Widget     |
+| `assertTappable`    | ✅         | `driver.execute('flutter:assertTappable', { label: 'Submit' })`                                                          | Widget     |
+| `tap`               | ✅         | `driver.execute('flutter:tap', [{ key: 'submit_button' }])`                                                              | Widget     |
+| `click`             | ✅         | `driver.execute('flutter:click', { text: 'Continue' })`                                                                  | Widget     |
+| `getText`           | ✅         | `driver.execute('flutter:getText', { key: 'counterText' })`                                                              | Widget     |
 
 ## 🔍 Input Formats
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -309,6 +309,21 @@ Please replace them properly with your client.
 | - | :ok: | (Ruby) `driver.execute_script 'flutter:connectObservatoryWsUrl'` | Flutter Driver |
 | - | :ok: | (Ruby) `driver.execute_script 'flutter:launchApp', 'bundleId', {arguments: ['arg1'], environment: {ENV1: 'env'}}` | Flutter Driver |
 
+## 📌 Additional Flutter Assertions (Custom)
+
+The following commands extend `appium-flutter-driver` to include widget visibility assertions. These are executed via the `driver.execute()` command (or your client equivalent).
+
+| **Assertion**      | **Status** | **Usage Example**                                                                                                                                                                                | **Target** |
+| ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| `assertVisible`    | ✅          | `driver.execute('flutter:assertVisible', { key: 'myKey' })`<br>`driver.execute('flutter:assertVisible', { text: 'Login' })`<br>`driver.execute('flutter:assertVisible', { label: 'Info icon' })` | Widget     |
+| `assertNotVisible` | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+| `assertTextEquals` | ✅          | `driver.execute('flutter:assertTextEquals', { key: 'greeting' }, 'Hello')`                                                                                                                       | Widget     |
+| `assertPresent`    | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+| `assertAbsent`     | ✅          | Same as above                                                                                                                                                                                    | Widget     |
+
+Flutter API	Status	WebDriver example (JavaScript, WebDriverIO)	Scope
+
+
 > **NOTE**
 > `flutter:launchApp` launches an app via instrument service. `mobile:activateApp` and `driver.activate_app` are via XCTest API. They are a bit different.
 

--- a/driver/lib/commands/assertions.ts
+++ b/driver/lib/commands/assertions.ts
@@ -1,89 +1,90 @@
 import { FlutterDriver } from '../driver';
-import { waitFor, waitForAbsent, waitForTappable } from './execute/wait';
 import { byValueKey, byText, byTooltip } from 'appium-flutter-finder';
 import type { SerializableFinder } from 'appium-flutter-finder';
 
-const serializeFinder = (finder: SerializableFinder): string => {
-  return Buffer.from(JSON.stringify(finder)).toString('base64');
-};
-
-type FinderInput =
+export type FinderInput =
   | { key: string }
   | { text: string }
-  | { label: string };
+  | { label: string }
+  | SerializableFinder
+  | string
+  | { getRawFinder: () => SerializableFinder }; // FlutterElement-like input
 
+// Serialize a finder to base64
+const serializeFinder = (finder: SerializableFinder): string =>
+  Buffer.from(JSON.stringify(finder)).toString('base64');
+
+// Type guards
+const isRawFinder = (input: any): input is SerializableFinder =>
+  input && typeof input === 'object' && typeof input.finderType === 'string';
+
+const isFlutterElementLike = (input: any): input is { getRawFinder: () => SerializableFinder } =>
+  input && typeof input === 'object' && typeof input.getRawFinder === 'function';
+
+// Convert FinderInput to base64 string
 function getFinderBase64(input: FinderInput): string {
+  if (typeof input === 'string') {
+    return input; // already base64
+  }
+
+  if (isFlutterElementLike(input)) {
+    return serializeFinder(input.getRawFinder());
+  }
+
+  if (isRawFinder(input)) {
+    return serializeFinder(input);
+  }
+
   if ('key' in input) {
     return serializeFinder(byValueKey(input.key));
   }
+
   if ('text' in input) {
     return serializeFinder(byText(input.text));
   }
+
   if ('label' in input) {
     return serializeFinder(byTooltip(input.label));
   }
-  throw new Error('Invalid finder input: must provide key, text, or label');
+
+  throw new Error('Invalid finder input: must provide key, text, label, raw finder, or FlutterElement');
 }
-/**
- * Asserts that an element is visible within a timeout.
- */
+
+// Generic helper to wrap assert commands
+async function executeAssertion(
+  driver: FlutterDriver,
+  command: string,
+  input: FinderInput,
+  timeout = 5000,
+  extraArgs: object = {}
+): Promise<void> {
+  const base64 = getFinderBase64(input);
+  try {
+    await driver.executeElementCommand(command, base64, { timeout, ...extraArgs });
+  } catch (err) {
+    throw new Error(`Assertion failed on command "${command}" within ${timeout}ms\n${err}`);
+  }
+}
+
+// Exported assertion commands
 export const assertVisible = async (
   driver: FlutterDriver,
   input: FinderInput,
   timeout = 5000
-): Promise<void> => {
-  try {
-    const base64 = getFinderBase64(input);
-    await waitFor(driver, base64, timeout);
-  } catch {
-    throw new Error(`Assertion failed: Element was not visible within ${timeout}ms`);
-  }
-};
+): Promise<void> =>
+  await executeAssertion(driver, 'waitFor', input, timeout, { visible: true });
 
-/**
- * Asserts that an element is NOT visible (i.e., removed from widget tree).
- */
 export const assertNotVisible = async (
   driver: FlutterDriver,
   input: FinderInput,
   timeout = 5000
-): Promise<void> => {
-  try {
-    const base64 = getFinderBase64(input);
-    await waitForAbsent(driver, base64, timeout);
-  } catch {
-    throw new Error(`Assertion failed: Element was still visible after ${timeout}ms`);
-  }
-};
+): Promise<void> =>
+  await executeAssertion(driver, 'waitForAbsent', input, timeout);
 
-/**
- * Asserts that an element is tappable.
- */
 export const assertTappable = async (
   driver: FlutterDriver,
   input: FinderInput,
   timeout = 5000
-): Promise<void> => {
-  try {
-    const base64 = getFinderBase64(input);
-    await waitForTappable(driver, base64, timeout);
-  } catch {
-    throw new Error(`Assertion failed: Element was not tappable within ${timeout}ms`);
-  }
-};
+): Promise<void> =>
+  await executeAssertion(driver, 'waitForTappable', input, timeout);
 
-/**
- * Asserts that a specific text is present.
- */
-export const assertTextPresent = async (
-  driver: FlutterDriver,
-  input: FinderInput,
-  timeout = 5000
-): Promise<void> => {
-  try {
-    const base64 = getFinderBase64(input);
-    await waitFor(driver, base64, timeout);
-  } catch {
-    throw new Error(`Assertion failed: Text was not found within ${timeout}ms`);
-  }
-};

--- a/driver/lib/commands/assertions.ts
+++ b/driver/lib/commands/assertions.ts
@@ -1,6 +1,11 @@
 import { FlutterDriver } from '../driver';
 import { waitFor, waitForAbsent, waitForTappable } from './execute/wait';
-import { byValueKey, byText, byTooltip, serializeFinder } from './finder';
+import { byValueKey, byText, byTooltip } from 'appium-flutter-finder';
+import type { SerializableFinder } from 'appium-flutter-finder';
+
+const serializeFinder = (finder: SerializableFinder): string => {
+  return Buffer.from(JSON.stringify(finder)).toString('base64');
+};
 
 type FinderInput =
   | { key: string }
@@ -19,7 +24,6 @@ function getFinderBase64(input: FinderInput): string {
   }
   throw new Error('Invalid finder input: must provide key, text, or label');
 }
-
 /**
  * Asserts that an element is visible within a timeout.
  */

--- a/driver/lib/commands/assertions.ts
+++ b/driver/lib/commands/assertions.ts
@@ -1,0 +1,85 @@
+import { FlutterDriver } from '../driver';
+import { waitFor, waitForAbsent, waitForTappable } from './execute/wait';
+import { byValueKey, byText, byTooltip, serializeFinder } from './finder';
+
+type FinderInput =
+  | { key: string }
+  | { text: string }
+  | { label: string };
+
+function getFinderBase64(input: FinderInput): string {
+  if ('key' in input) {
+    return serializeFinder(byValueKey(input.key));
+  }
+  if ('text' in input) {
+    return serializeFinder(byText(input.text));
+  }
+  if ('label' in input) {
+    return serializeFinder(byTooltip(input.label));
+  }
+  throw new Error('Invalid finder input: must provide key, text, or label');
+}
+
+/**
+ * Asserts that an element is visible within a timeout.
+ */
+export const assertVisible = async (
+  driver: FlutterDriver,
+  input: FinderInput,
+  timeout = 5000
+): Promise<void> => {
+  try {
+    const base64 = getFinderBase64(input);
+    await waitFor(driver, base64, timeout);
+  } catch {
+    throw new Error(`Assertion failed: Element was not visible within ${timeout}ms`);
+  }
+};
+
+/**
+ * Asserts that an element is NOT visible (i.e., removed from widget tree).
+ */
+export const assertNotVisible = async (
+  driver: FlutterDriver,
+  input: FinderInput,
+  timeout = 5000
+): Promise<void> => {
+  try {
+    const base64 = getFinderBase64(input);
+    await waitForAbsent(driver, base64, timeout);
+  } catch {
+    throw new Error(`Assertion failed: Element was still visible after ${timeout}ms`);
+  }
+};
+
+/**
+ * Asserts that an element is tappable.
+ */
+export const assertTappable = async (
+  driver: FlutterDriver,
+  input: FinderInput,
+  timeout = 5000
+): Promise<void> => {
+  try {
+    const base64 = getFinderBase64(input);
+    await waitForTappable(driver, base64, timeout);
+  } catch {
+    throw new Error(`Assertion failed: Element was not tappable within ${timeout}ms`);
+  }
+};
+
+/**
+ * Asserts that a specific text is present.
+ */
+export const assertTextPresent = async (
+  driver: FlutterDriver,
+  input: FinderInput,
+  timeout = 5000
+): Promise<void> => {
+  try {
+    const base64 = getFinderBase64(input);
+    await waitFor(driver, base64, timeout);
+  } catch {
+    throw new Error(`Assertion failed: Text was not found within ${timeout}ms`);
+  }
+};

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -1,254 +1,197 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { FlutterDriver } from '../driver';
 import { reConnectFlutterDriver } from '../sessions/session';
-import { longTap, scroll, scrollIntoView, scrollUntilVisible, scrollUntilTapable } from './execute/scroll';
-import { waitFor, waitForAbsent, waitForTappable } from './execute/wait';
+import {
+  longTap,
+  scroll,
+  scrollIntoView,
+  scrollUntilVisible,
+  scrollUntilTapable
+} from './execute/scroll';
+import {
+  waitFor,
+  waitForAbsent,
+  waitForTappable
+} from './execute/wait';
+import { getText } from './element';
+import { tap, click } from './gesture';
+import {
+  assertVisible,
+  assertNotVisible,
+  assertTappable,
+  type FinderInput
+} from './assertions';
+
 import { launchApp } from './../ios/app';
 import B from 'bluebird';
 
-
 const flutterCommandRegex = /^[\s]*flutter[\s]*:(.+)/;
 
-export const execute = async function(
+
+
+// Define types for better type safety
+type CommandHandler = (driver: FlutterDriver, ...args: any[]) => Promise<any>;
+type CommandMap = Record<string, CommandHandler>;
+
+interface DragAndDropParams {
+  startX: string;
+  startY: string;
+  endX: string;
+  endY: string;
+  duration: string;
+}
+
+interface DiagnosticsOptions {
+  subtreeDepth?: number;
+  includeProperties?: boolean;
+}
+
+
+
+interface LongTapOptions {
+  durationMilliseconds: number;
+  frequency?: number;
+}
+
+interface OffsetOptions {
+  offsetType: 'bottomLeft' | 'bottomRight' | 'center' | 'topLeft' | 'topRight';
+}
+
+// Extract command handlers into a separate object for better organization
+const commandHandlers: CommandMap = {
+  launchApp: async (driver, appId: string, opts = {}) => {
+    const { arguments: args = [], environment: env = {} } = opts;
+    await launchApp(driver.internalCaps.udid!, appId, args, env);
+    await reConnectFlutterDriver.bind(driver)(driver.internalCaps);
+  },
+  connectObservatoryWsUrl: async (driver) => {
+    await reConnectFlutterDriver.bind(driver)(driver.internalCaps);
+  },
+  checkHealth: async (driver) => (await driver.executeElementCommand('get_health')).status,
+  getVMInfo: async (driver) => await driver.executeGetVMCommand(),
+  getRenderTree: async (driver) => (await driver.executeElementCommand('get_render_tree')).tree,
+  getOffset: async (driver, elementBase64: string, options: OffsetOptions) => 
+    await driver.executeElementCommand('get_offset', elementBase64, options),
+  waitForCondition: async (driver, conditionName: string) => 
+    await driver.executeElementCommand('waitForCondition', '', { conditionName }),
+  forceGC: async (driver) => {
+    const response = await driver.socket!.call('_collectAllGarbage', {
+      isolateId: driver.socket!.isolateId,
+    }) as { type: string };
+    if (response.type !== 'Success') {
+      throw new Error(`Could not forceGC, response was ${JSON.stringify(response)}`);
+    }
+  },
+  setIsolateId: async (driver, isolateId: string) => {
+    driver.socket!.isolateId = isolateId;
+    return await driver.socket!.call('getIsolate', { isolateId });
+  },
+  getIsolate: async (driver, isolateId?: string) => 
+    await driver.executeGetIsolateCommand(isolateId || driver.socket!.isolateId!),
+  clearTimeline: async (driver) => {
+    const call1 = driver.socket!.call('_clearVMTimeline');
+    const call2 = driver.socket!.call('clearVMTimeline');
+    const response = await B.any([call1, call2]);
+    if (response.type !== 'Success') {
+      throw new Error(`Could not clear timeline, response was ${JSON.stringify(response)}`);
+    }
+  },
+  getRenderObjectDiagnostics: async (driver, elementBase64: string, opts: DiagnosticsOptions = {}) => {
+    const { subtreeDepth = 0, includeProperties = true } = opts;
+    return await driver.executeElementCommand('get_diagnostics_tree', elementBase64, {
+      diagnosticsType: 'renderObject',
+      includeProperties,
+      subtreeDepth,
+    });
+  },
+  getWidgetDiagnostics: async (driver, elementBase64: string, opts: DiagnosticsOptions = {}) => {
+    const { subtreeDepth = 0, includeProperties = true } = opts;
+    return await driver.executeElementCommand('get_diagnostics_tree', elementBase64, {
+      diagnosticsType: 'widget',
+      includeProperties,
+      subtreeDepth,
+    });
+  },
+  getSemanticsId: async (driver, elementBase64: string) => 
+    (await driver.executeElementCommand('get_semantics_id', elementBase64)).id,
+  waitForAbsent: async (driver, finder: string, timeout?: number) => 
+    await waitForAbsent(driver, finder, timeout),
+  waitFor: async (driver, finder: string, timeout?: number) => 
+    await waitFor(driver, finder, timeout),
+  waitForTappable: async (driver, finder: string, timeout?: number) => 
+    await waitForTappable(driver, finder, timeout),
+  scroll: async (driver, finder: string, opts: any) => 
+    await scroll(driver, finder, opts),
+  scrollUntilVisible: async (driver, finder: string, opts: any) => 
+    await scrollUntilVisible(driver, finder, opts),
+  scrollUntilTapable: async (driver, finder: string, opts: any) => 
+    await scrollUntilTapable(driver, finder, opts),
+  scrollIntoView: async (driver, finder: string, opts: any) => 
+    await scrollIntoView(driver, finder, opts),
+  setTextEntryEmulation: async (driver, enabled: boolean) => 
+    await driver.socket!.executeSocketCommand({ command: 'set_text_entry_emulation', enabled }),
+  enterText: async (driver, text: string) => 
+    await driver.socket!.executeSocketCommand({ command: 'enter_text', text }),
+  requestData: async (driver, message: string) => 
+    await driver.socket!.executeSocketCommand({ command: 'request_data', message }),
+  longTap: async (driver, finder: string, durationOrOptions?: number | LongTapOptions) => 
+  await longTap(driver, finder, durationOrOptions),   
+  waitForFirstFrame: async (driver) => 
+    await driver.executeElementCommand('waitForCondition', '', { conditionName: 'FirstFrameRasterizedCondition' }),
+  setFrameSync: async (driver, enabled: boolean, durationMilliseconds: number) => 
+    await driver.socket!.executeSocketCommand({
+      command: 'set_frame_sync',
+      enabled,
+      timeout: durationMilliseconds,
+    }),
+  clickElement: async (driver, finder: string, opts: { timeout?: number } = {}) => {
+    const { timeout = 1000 } = opts;
+    return await driver.executeElementCommand('tap', finder, { timeout });
+  },
+  dragAndDropWithCommandExtension: async (driver, params: DragAndDropParams) => 
+    await driver.socket!.executeSocketCommand({
+      command: 'dragAndDropWithCommandExtension',
+      ...params,
+    }),
+  assertVisible: async (driver, input: FinderInput, timeout = 5000) =>
+  await assertVisible(driver, input, timeout),
+
+  assertNotVisible: async (driver, input: FinderInput, timeout = 5000) =>
+    await assertNotVisible(driver, input, timeout),
+
+  assertTappable: async (driver, input: FinderInput, timeout = 5000) =>
+    await assertTappable(driver, input, timeout),
+  
+  tap: async (driver, gestures: Record<string, any>[], longPress: boolean = false) =>
+    await tap.call(driver, gestures, longPress),
+
+  click: async (driver, input: FinderInput) => await click.call(driver, input),
+
+  getText: async (driver: FlutterDriver, finder: string) =>
+    await getText.bind(driver)(finder),
+  getTextWithCommandExtension: async (driver, params: { findBy: string }) => 
+    await driver.socket!.executeSocketCommand({
+      command: 'getTextWithCommandExtension',
+      findBy: params.findBy,
+    }),
+};
+export const execute = async function (
   this: FlutterDriver,
   rawCommand: string,
   args: any[],
 ) {
-  // flutter
   const matching = rawCommand.match(flutterCommandRegex);
   if (!matching) {
-    throw new Error(`Command not support: "${rawCommand}"`);
+    throw new Error(`Command not supported: "${rawCommand}"`);
   }
 
   const command = matching[1].trim();
-  switch (command) {
-    case `launchApp`:
-      return await flutterLaunchApp(this, args[0], args[1]);
-    case `connectObservatoryWsUrl`:
-      return await connectObservatoryWsUrl(this);
-    case `getVMInfo`:
-      return await getVMInfo(this);
-    case `setIsolateId`:
-      return await setIsolateId(this, args[0]);
-    case `getIsolate`:
-      return await getIsolate(this, args[0]);
-    case `checkHealth`:
-      return await checkHealth(this);
-    case `clearTimeline`:
-      return await clearTimeline(this);
-    case `forceGC`:
-      return await forceGC(this);
-    case `getRenderTree`:
-      return await getRenderTree(this);
-    case `getBottomLeft`:
-      return await getOffset(this, args[0], { offsetType: `bottomLeft` });
-    case `getBottomRight`:
-      return await getOffset(this, args[0], { offsetType: `bottomRight` });
-    case `getCenter`:
-      return await getOffset(this, args[0], { offsetType: `center` });
-    case `getTopLeft`:
-      return await getOffset(this, args[0], { offsetType: `topLeft` });
-    case `getTopRight`:
-      return await getOffset(this, args[0], { offsetType: `topRight` });
-    case `getRenderObjectDiagnostics`:
-      return await getRenderObjectDiagnostics(this, args[0], args[1]);
-    case `getWidgetDiagnostics`:
-      return await getWidgetDiagnostics(this, args[0], args[1]);
-    case `getSemanticsId`:
-      return await getSemanticsId(this, args[0]);
-    case `waitForAbsent`:
-      return await waitForAbsent(this, args[0], args[1]);
-    case `waitFor`:
-      return await waitFor(this, args[0], args[1]);
-    case `waitForTappable`:
-      return await waitForTappable(this, args[0], args[1]);
-    case `scroll`:
-      return await scroll(this, args[0], args[1]);
-    case `scrollUntilVisible`:
-      return await scrollUntilVisible(this, args[0], args[1]);
-    case `scrollUntilTapable`:
-      return await scrollUntilTapable(this, args[0], args[1]);
-    case `scrollIntoView`:
-      return await scrollIntoView(this, args[0], args[1]);
-    case `setTextEntryEmulation`:
-      return await setTextEntryEmulation(this, args[0]);
-    case `enterText`:
-      return await enterText(this, args[0]);
-    case `requestData`:
-      return await requestData(this, args[0]);
-    case `longTap`:
-      return await longTap(this, args[0], args[1]);
-    case `waitForFirstFrame`:
-      return await waitForCondition(this, { conditionName: `FirstFrameRasterizedCondition`});
-    case `setFrameSync`:
-      return await setFrameSync(this, args[0], args[1]);
-    case `clickElement`:
-      return await clickElement(this, args[0], args[1]);
-    case `dragAndDropWithCommandExtension`:
-      return await dragAndDropWithCommandExtension(this, args[0]);
-    case `getTextWithCommandExtension`:
-      return await getTextWithCommandExtension(this, args[0]);
-    default:
-      throw new Error(`Command not support: "${rawCommand}"`);
+  const handler = commandHandlers[command];
+  
+  if (!handler) {
+    throw new Error(`Command not supported: "${rawCommand}"`);
   }
+
+  return await handler(this, ...args);
 };
 
-const flutterLaunchApp = async (
-  self: FlutterDriver, appId: string, opts
-) => {
-  const { arguments: args = [], environment: env = {}} = opts;
-  await launchApp(self.internalCaps.udid!, appId, args, env);
-  await reConnectFlutterDriver.bind(self)(self.internalCaps);
-};
-
-const connectObservatoryWsUrl = async (self: FlutterDriver) => {
-  await reConnectFlutterDriver.bind(self)(self.internalCaps);
-};
-
-const checkHealth = async (self: FlutterDriver) =>
-  (await self.executeElementCommand(`get_health`)).status;
-
-const getVMInfo = async (self: FlutterDriver) =>
-  (await self.executeGetVMCommand());
-
-const getRenderTree = async (self: FlutterDriver) =>
-  (await self.executeElementCommand(`get_render_tree`)).tree;
-
-const getOffset = async (
-  self: FlutterDriver,
-  elementBase64: string,
-  offsetType: {offsetType: string},
-) => await self.executeElementCommand(`get_offset`, elementBase64, offsetType);
-
-const waitForCondition = async (
-  self: FlutterDriver,
-  conditionName: {conditionName: string},
-) => await self.executeElementCommand(`waitForCondition`, ``, conditionName);
-
-const forceGC = async (self: FlutterDriver) => {
-  const response = await self.socket!.call(`_collectAllGarbage`, {
-    isolateId: self.socket!.isolateId,
-  }) as { type: string };
-  if (response.type !== `Success`) {
-    throw new Error(`Could not forceGC, response was ${response}`);
-  }
-};
-
-const setIsolateId = async (self: FlutterDriver, isolateId: string) => {
-  self.socket!.isolateId = isolateId;
-  return await self.socket!.call(`getIsolate`, {
-    isolateId: `${isolateId}`,
-  });
-};
-
-const getIsolate = async (
-  self: FlutterDriver, isolateId: string|undefined
-) => await self.executeGetIsolateCommand(isolateId || self.socket!.isolateId);
-
-const clearTimeline = async (self: FlutterDriver) => {
-  // @todo backward compatible, need to cleanup later
-  const call1: Promise<any> = self.socket!.call(`_clearVMTimeline`);
-  const call2: Promise<any> = self.socket!.call(`clearVMTimeline`);
-  const response = await B.any([call1, call2]);
-  if (response.type !== `Success`) {
-    throw new Error(`Could not forceGC, response was ${response}`);
-  }
-};
-
-const getRenderObjectDiagnostics = async (
-  self: FlutterDriver,
-  elementBase64: string,
-  opts: {
-    subtreeDepth: number;
-    includeProperties: boolean;
-  },
-) => {
-  const { subtreeDepth = 0, includeProperties = true } = opts;
-
-  return await self.executeElementCommand(
-    `get_diagnostics_tree`,
-    elementBase64,
-    {
-      diagnosticsType: `renderObject`,
-      includeProperties,
-      subtreeDepth,
-    },
-  );
-};
-
-const getWidgetDiagnostics = async (
-  self: FlutterDriver,
-  elementBase64: string,
-  opts: {
-    subtreeDepth: number;
-    includeProperties: boolean;
-  },
-) => {
-  const { subtreeDepth = 0, includeProperties = true } = opts;
-
-  return await self.executeElementCommand(
-    `get_diagnostics_tree`,
-    elementBase64,
-    {
-      diagnosticsType: `widget`,
-      includeProperties,
-      subtreeDepth,
-    },
-  );
-};
-
-const getSemanticsId = async (self: FlutterDriver, elementBase64: string) =>
-  (await self.executeElementCommand(`get_semantics_id`, elementBase64)).id;
-
-const enterText = async (self: FlutterDriver, text: string) =>
-  await self.socket!.executeSocketCommand({ command: `enter_text`, text });
-
-const requestData = async (self: FlutterDriver, message: string) =>
-  await self.socket!.executeSocketCommand({ command: `request_data`, message });
-
-const setFrameSync = async (self, bool: boolean, durationMilliseconds: number) =>
-  await self.socket!.executeSocketCommand({
-    command: `set_frame_sync`,
-    enabled: bool,
-    timeout: durationMilliseconds,
-  });
-
-const setTextEntryEmulation = async (self: FlutterDriver, enabled: boolean) =>
-  await self.socket!.executeSocketCommand({ command: `set_text_entry_emulation`, enabled });
-
-const clickElement = async (self:FlutterDriver, elementBase64: string, opts) => {
-  const {timeout = 1000} = opts;
-  return await self.executeElementCommand(`tap`, elementBase64, {
-        timeout
-  });
-};
-
-const dragAndDropWithCommandExtension = async (
-  self: FlutterDriver,
-  params: {
-    startX: string;
-    startY: string;
-    endX: string;
-    endY: string;
-    duration: string;
-  }
-) => {
-  const { startX, startY, endX, endY, duration } = params;
-  const commandPayload = {
-    command: 'dragAndDropWithCommandExtension',
-    startX,
-    startY,
-    endX,
-    endY,
-    duration,
-  };
-  return await self.socket!.executeSocketCommand(commandPayload);
-};
-
-const getTextWithCommandExtension = async (self: FlutterDriver, params: { findBy: string; }) => {
-  const payload = {
-      command: 'getTextWithCommandExtension',
-      findBy: params.findBy,
-  };
-  return await self.socket!.executeSocketCommand(payload);
-};

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -70,9 +70,9 @@ const commandHandlers: CommandMap = {
   checkHealth: async (driver) => (await driver.executeElementCommand('get_health')).status,
   getVMInfo: async (driver) => await driver.executeGetVMCommand(),
   getRenderTree: async (driver) => (await driver.executeElementCommand('get_render_tree')).tree,
-  getOffset: async (driver, elementBase64: string, options: OffsetOptions) => 
+  getOffset: async (driver, elementBase64: string, options: OffsetOptions) =>
     await driver.executeElementCommand('get_offset', elementBase64, options),
-  waitForCondition: async (driver, conditionName: string) => 
+  waitForCondition: async (driver, conditionName: string) =>
     await driver.executeElementCommand('waitForCondition', '', { conditionName }),
   forceGC: async (driver) => {
     const response = await driver.socket!.call('_collectAllGarbage', {
@@ -86,7 +86,7 @@ const commandHandlers: CommandMap = {
     driver.socket!.isolateId = isolateId;
     return await driver.socket!.call('getIsolate', { isolateId });
   },
-  getIsolate: async (driver, isolateId?: string) => 
+  getIsolate: async (driver, isolateId?: string) =>
     await driver.executeGetIsolateCommand(isolateId || driver.socket!.isolateId!),
   clearTimeline: async (driver) => {
     const call1 = driver.socket!.call('_clearVMTimeline');
@@ -112,33 +112,33 @@ const commandHandlers: CommandMap = {
       subtreeDepth,
     });
   },
-  getSemanticsId: async (driver, elementBase64: string) => 
+  getSemanticsId: async (driver, elementBase64: string) =>
     (await driver.executeElementCommand('get_semantics_id', elementBase64)).id,
-  waitForAbsent: async (driver, finder: string, timeout?: number) => 
+  waitForAbsent: async (driver, finder: string, timeout?: number) =>
     await waitForAbsent(driver, finder, timeout),
-  waitFor: async (driver, finder: string, timeout?: number) => 
+  waitFor: async (driver, finder: string, timeout?: number) =>
     await waitFor(driver, finder, timeout),
-  waitForTappable: async (driver, finder: string, timeout?: number) => 
+  waitForTappable: async (driver, finder: string, timeout?: number) =>
     await waitForTappable(driver, finder, timeout),
-  scroll: async (driver, finder: string, opts: any) => 
+  scroll: async (driver, finder: string, opts: any) =>
     await scroll(driver, finder, opts),
-  scrollUntilVisible: async (driver, finder: string, opts: any) => 
+  scrollUntilVisible: async (driver, finder: string, opts: any) =>
     await scrollUntilVisible(driver, finder, opts),
-  scrollUntilTapable: async (driver, finder: string, opts: any) => 
+  scrollUntilTapable: async (driver, finder: string, opts: any) =>
     await scrollUntilTapable(driver, finder, opts),
-  scrollIntoView: async (driver, finder: string, opts: any) => 
+  scrollIntoView: async (driver, finder: string, opts: any) =>
     await scrollIntoView(driver, finder, opts),
-  setTextEntryEmulation: async (driver, enabled: boolean) => 
+  setTextEntryEmulation: async (driver, enabled: boolean) =>
     await driver.socket!.executeSocketCommand({ command: 'set_text_entry_emulation', enabled }),
-  enterText: async (driver, text: string) => 
+  enterText: async (driver, text: string) =>
     await driver.socket!.executeSocketCommand({ command: 'enter_text', text }),
-  requestData: async (driver, message: string) => 
+  requestData: async (driver, message: string) =>
     await driver.socket!.executeSocketCommand({ command: 'request_data', message }),
-  longTap: async (driver, finder: string, durationOrOptions?: number | LongTapOptions) => 
-  await longTap(driver, finder, durationOrOptions),   
-  waitForFirstFrame: async (driver) => 
+  longTap: async (driver, finder: string, durationOrOptions?: LongTapOptions) => 
+    await longTap(driver, finder, durationOrOptions),   
+  waitForFirstFrame: async (driver) =>
     await driver.executeElementCommand('waitForCondition', '', { conditionName: 'FirstFrameRasterizedCondition' }),
-  setFrameSync: async (driver, enabled: boolean, durationMilliseconds: number) => 
+  setFrameSync: async (driver, enabled: boolean, durationMilliseconds: number) =>
     await driver.socket!.executeSocketCommand({
       command: 'set_frame_sync',
       enabled,
@@ -148,7 +148,7 @@ const commandHandlers: CommandMap = {
     const { timeout = 1000 } = opts;
     return await driver.executeElementCommand('tap', finder, { timeout });
   },
-  dragAndDropWithCommandExtension: async (driver, params: DragAndDropParams) => 
+  dragAndDropWithCommandExtension: async (driver, params: DragAndDropParams) =>
     await driver.socket!.executeSocketCommand({
       command: 'dragAndDropWithCommandExtension',
       ...params,
@@ -161,15 +161,13 @@ const commandHandlers: CommandMap = {
 
   assertTappable: async (driver, input: FinderInput, timeout = 5000) =>
     await assertTappable(driver, input, timeout),
-  
+
   tap: async (driver, gestures: Record<string, any>[], longPress: boolean = false) =>
     await tap.call(driver, gestures, longPress),
 
   click: async (driver, input: FinderInput) => await click.call(driver, input),
 
-  getText: async (driver: FlutterDriver, finder: string) =>
-    await getText.bind(driver)(finder),
-  getTextWithCommandExtension: async (driver, params: { findBy: string }) => 
+  getTextWithCommandExtension: async (driver, params: { findBy: string }) =>
     await driver.socket!.executeSocketCommand({
       command: 'getTextWithCommandExtension',
       findBy: params.findBy,
@@ -187,7 +185,7 @@ export const execute = async function (
 
   const command = matching[1].trim();
   const handler = commandHandlers[command];
-  
+
   if (!handler) {
     throw new Error(`Command not supported: "${rawCommand}"`);
   }

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -6,14 +6,15 @@ import {
   scroll,
   scrollIntoView,
   scrollUntilVisible,
-  scrollUntilTapable
+  scrollUntilTapable,
+  pageBack
 } from './execute/scroll';
 import {
   waitFor,
   waitForAbsent,
   waitForTappable
 } from './execute/wait';
-import { getText } from './element';
+import { clear, getText } from './element';
 import { tap, click } from './gesture';
 import {
   assertVisible,
@@ -165,8 +166,14 @@ const commandHandlers: CommandMap = {
   tap: async (driver, gestures: Record<string, any>[], longPress: boolean = false) =>
     await tap.call(driver, gestures, longPress),
 
-  click: async (driver, input: FinderInput) => await click.call(driver, input),
-  getText: async (driver, element: string) => await getText.call(driver, element),
+  click: async (driver, input: FinderInput) => 
+    await click.call(driver, input),
+  getText: async (driver, element: string) => 
+    await getText.call(driver, element),
+  pageBack: async (driver) => 
+    await pageBack.call(driver),
+  clear:    async (driver, input: FinderInput) => 
+    await clear.call(driver, input),
 
   getTextWithCommandExtension: async (driver, params: { findBy: string }) =>
     await driver.socket!.executeSocketCommand({

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -134,8 +134,8 @@ const commandHandlers: CommandMap = {
     await driver.socket!.executeSocketCommand({ command: 'enter_text', text }),
   requestData: async (driver, message: string) =>
     await driver.socket!.executeSocketCommand({ command: 'request_data', message }),
-  longTap: async (driver, finder: string, durationOrOptions?: LongTapOptions) => 
-    await longTap(driver, finder, durationOrOptions),   
+  longTap: async (driver, finder: string, durationOrOptions?: LongTapOptions) =>
+    await longTap(driver, finder, durationOrOptions),
   waitForFirstFrame: async (driver) =>
     await driver.executeElementCommand('waitForCondition', '', { conditionName: 'FirstFrameRasterizedCondition' }),
   setFrameSync: async (driver, enabled: boolean, durationMilliseconds: number) =>
@@ -154,7 +154,7 @@ const commandHandlers: CommandMap = {
       ...params,
     }),
   assertVisible: async (driver, input: FinderInput, timeout = 5000) =>
-  await assertVisible(driver, input, timeout),
+    await assertVisible(driver, input, timeout),
 
   assertNotVisible: async (driver, input: FinderInput, timeout = 5000) =>
     await assertNotVisible(driver, input, timeout),
@@ -166,6 +166,7 @@ const commandHandlers: CommandMap = {
     await tap.call(driver, gestures, longPress),
 
   click: async (driver, input: FinderInput) => await click.call(driver, input),
+  getText: async (driver, element: string) => await getText.call(driver, element),
 
   getTextWithCommandExtension: async (driver, params: { findBy: string }) =>
     await driver.socket!.executeSocketCommand({

--- a/driver/lib/commands/execute.ts
+++ b/driver/lib/commands/execute.ts
@@ -166,13 +166,13 @@ const commandHandlers: CommandMap = {
   tap: async (driver, gestures: Record<string, any>[], longPress: boolean = false) =>
     await tap.call(driver, gestures, longPress),
 
-  click: async (driver, input: FinderInput) => 
+  click: async (driver, input: FinderInput) =>
     await click.call(driver, input),
-  getText: async (driver, element: string) => 
+  getText: async (driver, element: string) =>
     await getText.call(driver, element),
-  pageBack: async (driver) => 
+  pageBack: async (driver) =>
     await pageBack.call(driver),
-  clear:    async (driver, input: FinderInput) => 
+  clear: async (driver, input: FinderInput) =>
     await clear.call(driver, input),
 
   getTextWithCommandExtension: async (driver, params: { findBy: string }) =>

--- a/driver/lib/commands/execute/scroll.ts
+++ b/driver/lib/commands/execute/scroll.ts
@@ -204,3 +204,13 @@ export const scrollIntoView = async (
 
   return await self.executeElementCommand(`scrollIntoView`, elementBase64, args);
 };
+
+
+export const pageBack = async function (this: FlutterDriver): Promise<void> {
+  if (this.proxydriver && typeof this.proxydriver.back === 'function') {
+    return await this.proxydriver.back(); // use platform driver
+  }
+
+  // fallback
+  throw new Error(`Back navigation is not supported on this platform.`);
+};

--- a/driver/lib/commands/execute/scroll.ts
+++ b/driver/lib/commands/execute/scroll.ts
@@ -43,26 +43,24 @@ export const scroll = async (
 export const longTap = async (
   self: FlutterDriver,
   elementBase64: string,
-  opts: {
+  durationOrOptions: number | {
     durationMilliseconds: number;
     frequency?: number;
-  },
+  } = 1000, // Default to 1000ms if nothing provided
 ) => {
-  const { durationMilliseconds, frequency = 60 } = opts;
+  const options = typeof durationOrOptions === 'number'
+    ? { durationMilliseconds: durationOrOptions }
+    : durationOrOptions;
 
-  if (
-    typeof durationMilliseconds !== `number` ||
-    typeof frequency !== `number`
-  ) {
-    // @todo BaseDriver's errors.InvalidArgumentError();
-    throw new Error(`${opts} is not a valid options`);
+  const { durationMilliseconds, frequency = 60 } = options;
+
+  if (typeof durationMilliseconds !== 'number' || typeof frequency !== 'number') {
+    throw new Error(`Invalid longTap options: ${JSON.stringify(options)}`);
   }
 
-  return await self.executeElementCommand(`scroll`, elementBase64, {
+  return await self.executeElementCommand('scroll', elementBase64, {
     dx: 0,
     dy: 0,
-    // 'scroll' expects microseconds
-    // https://github.com/flutter/flutter/blob/master/packages/flutter_driver/lib/src/common/gesture.dart#L33-L38
     duration: durationMilliseconds * 1000,
     frequency,
   });

--- a/driver/package.json
+++ b/driver/package.json
@@ -69,8 +69,9 @@
     "typescript": "~5.8"
   },
   "dependencies": {
-    "appium-ios-device": "^2.7.18",
     "appium-android-driver": "^10.0.0",
+    "appium-flutter-finder": "^0.2.0",
+    "appium-ios-device": "^2.7.18",
     "appium-uiautomator2-driver": "^4.2.3",
     "appium-xcuitest-driver": "^9.2.3",
     "asyncbox": "^3.0.0",

--- a/driver/tsconfig.json
+++ b/driver/tsconfig.json
@@ -7,7 +7,6 @@
     "outDir": "build",
     "types": ["node"],
     "checkJs": true
-
   },
   "include": ["lib"]
 }

--- a/driver/tsconfig.json
+++ b/driver/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "build",
     "types": ["node"],
     "checkJs": true
+
   },
   "include": ["lib"]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "appium-flutter-finder": "^0.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.18"
+  }
+}


### PR DESCRIPTION
This PR adds support for custom visibility assertions and utility actions in the appium-flutter-driver, including:

✅ Added Custom Commands:

flutter:assertVisible
flutter:assertNotVisible
flutter:assertTappable
flutter:tap
flutter:click
flutter:getText
flutter:pageBack
flutter:clear

These commands allow clients to:
Verify widget visibility and tappability using Flutter finders (e.g., by key, text, or label, encoded in base64)
Interact with UI elements via tap, click, and clear
Navigate back in the app (pageBack)
Retrieve widget text content (getText)

All commands have been locally tested and validated on real devices with a variety of Flutter widget trees to ensure correct behavior and compatibility..