### PR TITLE
feat: do not reconnect the Dart VM in activate app in FLUTTER context

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ You have a couple of methods to start the application under test by establishing
     1. Start a session without `app` capability
     2. Install the application under test via `driver.install_app` or `mobile:installApp` command
     3. Activate the app via `driver.activate_app` or `mobile:activateApp` command
-        - Then, appium-flutter-driver establish a connection with the Dart VM
+        - Then, appium-flutter-driver establish a connection with the Dart VM in `FLUTTER` context
 3. Launch the app outside the driver: for users who want to manage the application under test by yourselves
     1. Start a session without `app` capability
     2. Install the application under test via `driver.install_app` or `mobile:installApp` command etc

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ These Appium commands can work across context
 - `getContexts`
 - `activateApp('appId')`/`mobile:activateApp`
     - `mobile:activateApp` has `skipAttachObservatoryUrl` key to not try to attach to an observatory url. e.g. `driver.execute_script 'mobile:activateApp', {skipAttachObservatoryUrl: true, appId: 'com.android.chrome'}`
+    - `activateApp` command skip reconnecting the DartVM when the process is alreday running
 - `terminateApp('appId')`/`mobile:terminateApp`
 - `installApp(appPath, options)`
 - `getClipboard`

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ These Appium commands can work across context
 - `getContexts`
 - `activateApp('appId')`/`mobile:activateApp`
     - `mobile:activateApp` has `skipAttachObservatoryUrl` key to not try to attach to an observatory url. e.g. `driver.execute_script 'mobile:activateApp', {skipAttachObservatoryUrl: true, appId: 'com.android.chrome'}`
-    - `activateApp` command skip reconnecting the DartVM when the process is alreday running
+    - `activateApp` command skips reconnecting the DartVM when the process is already running
 - `terminateApp('appId')`/`mobile:terminateApp`
 - `installApp(appPath, options)`
 - `getClipboard`

--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.18.0
-- Skip reconnecting the Dart VM if `activateApp` command was called for already running app in the background or foreground.
+- Skip reconnecting the Dart VM if `activateApp` command was called for already running app in the background or foreground in `FLUTTER` context
     - Such a reconnection works only for newly started processes
 
 ## 2.17.0

--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.18.0
+- Skip reconnecting the Dart VM if `activateApp` command was called for already running app in the background or foreground.
+    - Such a reconnection works only for newly started processes
+
 ## 2.17.0
 - Fix ending forwarding port with `forwardingPort` capability on iOS with `terminateApp`
 - Update Appium XCUITest driver dependency to 9.6.1

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -217,20 +217,12 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
   }
 
   public async executeCommand(cmd: string, ...args: [string, [{
-    skipAttachObservatoryUrl: string, appId: string, bundleId: string, any: any
+    skipAttachObservatoryUrl: string, any: any
   }]]) {
     if (new RegExp(/^[\s]*mobile:[\s]*activateApp$/).test(args[0])) {
-      const { skipAttachObservatoryUrl = false, appId = null, bundleId = null} = args[1][0];
-
-      if (skipAttachObservatoryUrl) {
-        await this.proxydriver.executeCommand(cmd, ...args);
-        return;
-      }
-
-      const appState = await this.proxydriver.queryAppState(appId || bundleId);
+      const { skipAttachObservatoryUrl = false} = args[1][0];
       await this.proxydriver.executeCommand(cmd, ...args);
-      if (appState === 3 || appState === 4) { return; }
-
+      if (skipAttachObservatoryUrl) { return; }
       await reConnectFlutterDriver.bind(this)(this.internalCaps);
       return;
     } else if (new RegExp(/^[\s]*mobile:[\s]*terminateApp$/).test(args[0])) {

--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -220,7 +220,7 @@ class FlutterDriver extends BaseDriver<FluttertDriverConstraints> {
     skipAttachObservatoryUrl: string, any: any
   }]]) {
     if (new RegExp(/^[\s]*mobile:[\s]*activateApp$/).test(args[0])) {
-      const { skipAttachObservatoryUrl = false} = args[1][0];
+      const { skipAttachObservatoryUrl = false } = args[1][0];
       await this.proxydriver.executeCommand(cmd, ...args);
       if (skipAttachObservatoryUrl) { return; }
       await reConnectFlutterDriver.bind(this)(this.internalCaps);

--- a/example/ruby/example_sample2.rb
+++ b/example/ruby/example_sample2.rb
@@ -12,7 +12,7 @@ class ExampleTests < Minitest::Test
       automationName: 'flutter',
       udid: 'emulator-5554',
       deviceName: 'Android',
-      app: "#{Dir.pwd}/../../example/sample2/app-debug.apk",
+      app: "#{Dir.pwd}/../example/sample2/app-debug.apk",
       maxRetryCount: 60,
       retryBackoffTime: 10000,
     },
@@ -71,7 +71,16 @@ class ExampleTests < Minitest::Test
     element = @driver.wait_until { |d| d.find_element :id, 'dev.flutter.example.androidfullscreen:id/counter_label' }
     assert_equal 'Current count: 2', element.text
 
+    @driver.background_app(-1)
+
     @driver.context = 'FLUTTER'
+
+    @driver.activate_app 'dev.flutter.example.androidfullscreen'
+
+    text_finder = by_text 'Tap me!'
+    element = ::Appium::Flutter::Element.new(@driver, finder: text_finder)
+    assert_equal 'Tap me!', element.text
+
     @driver.terminate_app 'dev.flutter.example.androidfullscreen'
     @driver.activate_app 'dev.flutter.example.androidfullscreen'
 

--- a/example/ruby/example_sample2.rb
+++ b/example/ruby/example_sample2.rb
@@ -12,7 +12,7 @@ class ExampleTests < Minitest::Test
       automationName: 'flutter',
       udid: 'emulator-5554',
       deviceName: 'Android',
-      app: "#{Dir.pwd}/../example/sample2/app-debug.apk",
+      app: "#{Dir.pwd}/example/sample2/app-debug.apk",
       maxRetryCount: 60,
       retryBackoffTime: 10000,
     },


### PR DESCRIPTION
To close https://github.com/appium/appium-flutter-driver/issues/810#issuecomment-2981224305

Currently, the active app command in Flutter context attempts to reconnect the Dart VM, but if the activate app is called for an already running app, the reconnection will fail because it doesn't provide a new websocket URL.

This PR skips handling such a reconnection for an already running app. This change is only for activate_app endpoint. `mobile:activateApp` can do the same thing explicitly for such an intentional use case.