### PR TITLE
fix(ios): retry device-log capture so VM-service discovery survives flaky simctl

### DIFF
--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -43,6 +43,35 @@ export async function startIOSSession(
     return [iosdriver, null];
   }
 
+  // appium-xcuitest starts the device-log capture by spawning `xcrun simctl spawn <udid> log
+  // stream`, which on loaded CI simulators intermittently fails to start ("The process did not
+  // start within 10000ms") or hits a transient "Simulator is not running". appium swallows that
+  // error ("Continuing without capturing device logs") without retrying, leaving `this._logmon`
+  // unset — and since the Dart VM Service URL binds a random, auth-coded port that can only be read
+  // from that log, getObservatoryWsUri() below would throw "mandatory syslog service must be
+  // running". Re-invoke the capture a few times: a success re-emits `syslogStarted`, which the
+  // once-handler registered above turns into `this._logmon`. Only the log-discovery path needs it.
+  if (!caps.observatoryWsUri && !this._logmon) {
+    const maxAttempts = 5;
+    for (let attempt = 1; attempt <= maxAttempts && !this._logmon; attempt += 1) {
+      this.log.warn(
+        `Device-log capture did not start during session create; retrying (attempt ${attempt}/${maxAttempts})`,
+      );
+      await B.delay(2000);
+      try {
+        await iosdriver.startLogCapture();
+      } catch (e) {
+        this.log.debug(`startLogCapture retry ${attempt} failed: ${(e as Error).stack ?? e}`);
+      }
+    }
+    if (!this._logmon) {
+      this.log.warn(
+        `Device-log capture still not started after ${maxAttempts} retries; ` +
+          `getObservatoryWsUri will fall back to dartVmServicePort if set, otherwise fail.`,
+      );
+    }
+  }
+
   return [iosdriver, await connectIOSSession.bind(this)(iosdriver, caps)];
 }
 


### PR DESCRIPTION
Standalone iOS reliability fix, independent of #880.

## Problem

On loaded CI simulators, appium-xcuitest's `IOSSimulatorLog.startCapture()` (`xcrun simctl spawn <udid> log stream`) intermittently fails to start — "The process did not start within 10000ms" or a transient "Simulator is not running" — and appium swallows the error ("Continuing without capturing device logs") without retrying. That leaves `this._logmon` unset, and because the iOS engine binds a random, auth-coded Dart VM Service port whose URL can only be read from the device log, `getObservatoryWsUri()` then throws "The mandatory syslog service must be running …", failing the session.

This is the same class of flake behind iOS reports like #731 ("No observatory URL matching …") and #758 ("Cannot connect to the Dart Observatory URL").

## Fix

After `createSession`, when the log monitor didn't come up (and `observatoryWsUri` isn't set), re-invoke `startLogCapture()` up to 5× with a short backoff. A success re-emits `syslogStarted`, which the existing once-handler turns into `this._logmon`. The happy path (capture started first try) is untouched, and only the log-discovery path needs it — if `dartVmServicePort` (#870) is set, discovery has its own fallback regardless.

Observed ~2/5 iOS sessions hitting this per CI run; the retry recovers them. `tsc -b` clean.



This surfaced as a recurring session-create flake in [`@wdio/flutter-service`](https://github.com/webdriverio/desktop-mobile)'s **iOS** Flutter e2e on CI; the retry is what cleared it.
